### PR TITLE
Go back to markdown headers

### DIFF
--- a/pydocmd/document.py
+++ b/pydocmd/document.py
@@ -57,9 +57,7 @@ class Section(object):
     Render the section into *stream*.
     """
 
-    print('<h{depth} id="{id}">{title}</h{depth}>\n'
-      .format(depth = self.depth, id = self.identifier, title = self.title),
-      file = stream)
+    print('#' * self.depth, self.title, file = stream)
     print(self.content, file=stream)
 
   @property


### PR DESCRIPTION
This reverts the functionality back to before these headers were added as HTML.  The upside is that
https://github.com/NiklasRosenstein/pydoc-markdown/issues/11 no longer causes generated sections to not have a table of contents, but the downside is we don't get the unique header id tags which was the goal of the change in the first place.